### PR TITLE
fix: check redirect in authenticate

### DIFF
--- a/ecospheres_migrator/app.py
+++ b/ecospheres_migrator/app.py
@@ -24,6 +24,7 @@ from ecospheres_migrator.batch import (
     SuccessTransformBatchRecord,
     TransformBatchRecord,
 )
+from ecospheres_migrator.geonetwork import GeonetworkConnectionError
 from ecospheres_migrator.migrator import Migrator
 from ecospheres_migrator.queue import get_job, get_queue
 
@@ -54,7 +55,7 @@ def login():
     try:
         migrator = Migrator(url=url, username=username, password=password)
         gn_info = migrator.gn.info()
-    except requests.exceptions.RequestException as e:
+    except (requests.exceptions.RequestException, GeonetworkConnectionError) as e:
         flash(f"Problème d'authentification ({e})", "error")
         return redirect(url_for("login_form"))
     else:

--- a/ecospheres_migrator/geonetwork.py
+++ b/ecospheres_migrator/geonetwork.py
@@ -93,11 +93,12 @@ class GeonetworkClient:
             raise GeonetworkConnectionError(
                 f"Redirection détectée vers {r.headers['Location']}. Merci d'utiliser l'URL canonique du serveur."
             )
-        # don't abort on error here, it's expected
         xsrf_token = r.cookies.get("XSRF-TOKEN")
         if xsrf_token:
             self.session.headers.update({"X-XSRF-TOKEN": xsrf_token})
-        log.debug(f"XSRF token: {xsrf_token}")
+            log.debug(f"XSRF token: {xsrf_token}")
+        else:
+            raise GeonetworkConnectionError("Impossible de récupérer le token XSRF")
 
     def _get_md_type(self, md: dict) -> MetadataType:
         return MetadataType(md.get("isTemplate", MetadataType.METADATA))


### PR DESCRIPTION
The `authenticate()` logic will fail silently if a redirect is followed, probably because the `POST` request is converted to a `GET`. This happens for example when an https-forced website is requested through http.

When this happens, we don't get the cookie 🍪 and all hell breaks loose in the following steps:
- migrating in place will fail silently (record is not updated and a success is registered)
- duplicating records will fail with a `403`

This checks explicitly for a redirect in `authenticate()` and blocks the process.

But maybe we should fail if we don't get the cookie 🍪? The comment says `don't abort on error here, it's expected`, so I did not go this way. Is there an identified case where we expect this to fail and still want to proceed?

<img width="978" alt="Capture d’écran 2024-09-23 à 09 52 05" src="https://github.com/user-attachments/assets/4206de73-b871-470f-9167-3f9702ed0c95">
